### PR TITLE
Fix codesandbox config to use the correct template

### DIFF
--- a/sandbox.config.json
+++ b/sandbox.config.json
@@ -1,5 +1,5 @@
 {
-  "template": "node",
+  "template": "quasar",
   "container": {
     "node": "14"
   }


### PR DESCRIPTION
A user reported that the quasar template has the wrong icon, we found that this is probably the cause.

If it's correct, this screen will show the quasar logo

![image](https://user-images.githubusercontent.com/1862172/140089010-8852217e-74e8-4981-9847-d2f5a0ace00c.png)

Thank you!